### PR TITLE
pyautogui: guard checks behind hostPlatform.isLinux

### DIFF
--- a/pkgs/development/python-modules/pyautogui/default.nix
+++ b/pkgs/development/python-modules/pyautogui/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   mouseinfo,
@@ -25,11 +26,14 @@ buildPythonPackage {
     hash = "sha256-R9tcTqxUaqw63FLOGFRaO/Oz6kD7V6MPHdQ8A29NdXw=";
   };
 
-  nativeCheckInputs = [
+  doCheck = stdenv.hostPlatform.isLinux;
+
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isLinux [
     xvfb-run
     scrot
   ];
-  checkPhase = ''
+
+  checkPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
     xvfb-run python -c 'import pyautogui'
     # The tests depend on some specific things that xvfb cant provide, like keyboard and mouse
     # xvfb-run python -m unittest tests.test_pyautogui


### PR DESCRIPTION
## Summary
- wrap pyautogui test dependencies and check phase with `stdenv.hostPlatform.isLinux`

## Testing
- `nix shell nixpkgs#nixfmt -c nixfmt pkgs/development/python-modules/pyautogui/default.nix` *(failed: unable to download bash-5.3.tar.gz)*
- `nix-build -A python3Packages.pyautogui --no-out-link` *(failed: unable to download bash-5.3.tar.gz)*

------
https://chatgpt.com/codex/tasks/task_e_689b0d221508832d99119176b0d8f89e